### PR TITLE
Better Specification/Implementation Conformity

### DIFF
--- a/syntax/dockerfile.vim
+++ b/syntax/dockerfile.vim
@@ -11,8 +11,8 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax keyword dockerfileKeyword FROM MAINTAINER RUN CMD EXPOSE ENV ADD
-syntax keyword dockerfileKeyword ENTRYPOINT VOLUME USER WORKDIR
+syntax match dockerfileKeyword /\v^\s*(FROM|MAINTAINER|RUN|CMD|EXPOSE|ENV|ADD)\s/
+syntax match dockerfileKeyword /\v^\s*(ENTRYPOINT|VOLUME|USER|WORKDIR)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/


### PR DESCRIPTION
Just added a few little tweaks to follow the `Dockerfile` [documentation](http://docs.docker.io/en/latest/use/builder/#format) and [implementation](https://github.com/dotcloud/docker/blob/v0.6.1/buildfile.go#L490-L502) more closely, namely:
- commands are technically case-insensitive
- only lines which begin with a # are truly comments
- commands are only commands at the beginning of the line (and on a similar note, all commands MUST have at least one argument, hence the safe matching of `\s` after commands)
