### PR TITLE
Set commentstring

### DIFF
--- a/syntax/dockerfile.vim
+++ b/syntax/dockerfile.vim
@@ -20,3 +20,5 @@ highlight link dockerfileString String
 
 syntax match dockerfileComment "\v^\s*#.*$"
 highlight link dockerfileComment Comment
+
+set commentstring=#\ %s


### PR DESCRIPTION
By setting the commentstring, you support commenting with plugins like tComment. Now Vim won't default to `/* */` comments.
