### PR TITLE
Support for Dockerfile.<suffix> detection

### DIFF
--- a/ftdetect/dockerfile.vim
+++ b/ftdetect/dockerfile.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead Dockerfile.* set filetype=dockerfile
+au BufNewFile,BufRead Dockerfile* set filetype=dockerfile

--- a/ftdetect/dockerfile.vim
+++ b/ftdetect/dockerfile.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead Dockerfile set filetype=dockerfile
+au BufNewFile,BufRead Dockerfile.* set filetype=dockerfile


### PR DESCRIPTION
That's a trivial fix to add a support for `Dockerfile.<suffix>` file names (i.e. `Dockerfile.dev` or `Dockerfile.prod`). 

As far as I'm concerned it is a fairly popular naming pattern when you have different Dockerfiles for different development stages (fat image for development, minimal for production etc.). At least I do use this pattern myself.

Please consider merging!

